### PR TITLE
使用するフォントの定義を行いました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "my-work",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/cuprum": "^5.0.11",
+        "@fontsource/dotgothic16": "^5.0.10",
+        "@fontsource/inter": "^5.0.8",
+        "@fontsource/nosifer": "^5.0.11",
+        "@fontsource/road-rage": "^5.0.11",
         "@nextui-org/react": "^2.1.7",
         "@types/node": "18.16.0",
         "@types/react": "18.0.38",
@@ -17,6 +22,7 @@
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
         "eslint-plugin-sort": "^2.10.0",
+        "fontsource-frijole": "^4.0.0",
         "next": "13.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -129,6 +135,31 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@fontsource/cuprum": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/cuprum/-/cuprum-5.0.11.tgz",
+      "integrity": "sha512-9B6ubWQwkIOjk5cdyEia7wfIVQCncUD/c92kckztDP6RDc5Y13zCXONYv2ZH8Mo7XVlutXS2guXeaAnAa5Uiow=="
+    },
+    "node_modules/@fontsource/dotgothic16": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/dotgothic16/-/dotgothic16-5.0.10.tgz",
+      "integrity": "sha512-EDIpwvWp/OFhmm8QNDU56Q2IoTQdB7SG56eYiUXBQ5v0MC/kJsQjW+cbxvsHug+JWZIUD3hq0Z8vGeFcqu0jdA=="
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.0.8.tgz",
+      "integrity": "sha512-28knWH1BfOiRalfLs90U4sge5mpQ8ZH6FS0PTT+IZMKrZ7wNHDHRuKa1kQJg+uHcc6axBppnxll+HXM4c7zo/Q=="
+    },
+    "node_modules/@fontsource/nosifer": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/nosifer/-/nosifer-5.0.11.tgz",
+      "integrity": "sha512-TNls1myY6OaKAj2UZsLsq7CyYN6ciAqbeSYGMaqiynD+VE3C2khbUiL337BEvk4nD75fqcU4y5Kaa+89HuI42Q=="
+    },
+    "node_modules/@fontsource/road-rage": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/road-rage/-/road-rage-5.0.11.tgz",
+      "integrity": "sha512-N9ovAMVsvuBxVrImq3ZSqiKgv8kT51Zy9xvEFC9z2MiCSXh0Y1bVTpRyqmm6fVBPJBD4+1EphAzrFua07hUSeQ=="
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.17.0",
@@ -4630,6 +4661,12 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "node_modules/fontsource-frijole": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fontsource-frijole/-/fontsource-frijole-4.0.0.tgz",
+      "integrity": "sha512-FHA2rMl+E9y573BWViI7z6aqji+7j5ooJv7phjSuyynjnqu8f49hJ3i19YsR3nnApyGuU5FFoRCab6X3dFxprg==",
+      "deprecated": "Package relocated. Please install and migrate to @fontsource/frijole."
     },
     "node_modules/for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@fontsource/cuprum": "^5.0.11",
+    "@fontsource/dotgothic16": "^5.0.10",
+    "@fontsource/inter": "^5.0.8",
+    "@fontsource/nosifer": "^5.0.11",
+    "@fontsource/road-rage": "^5.0.11",
     "@nextui-org/react": "^2.1.7",
     "@types/node": "18.16.0",
     "@types/react": "18.0.38",
@@ -19,6 +24,7 @@
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.1",
     "eslint-plugin-sort": "^2.10.0",
+    "fontsource-frijole": "^4.0.0",
     "next": "13.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,10 @@
+@import '@fontsource/nosifer';
+@import '@fontsource/cuprum';
+@import '@fontsource/dotgothic16';
+@import '@fontsource/inter';
+@import '@fontsource/road-rage';
+@import 'fontsource-frijole';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -1,7 +1,3 @@
-import { Button } from '@nextui-org/button';
-import { Card, CardBody, CardFooter, CardHeader } from '@nextui-org/card';
-import { Divider } from '@nextui-org/divider';
-import { Input } from '@nextui-org/input';
 import { NextPage } from 'next';
 import React from 'react';
 

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -9,22 +9,12 @@ const RootPage: NextPage = () => {
   return (
     <>
       <div className='bg-base-secondary'>kurakke</div>
-      <Card className='max-w-sm mx-auto'>
-        <CardHeader className='flex items-center justify-center'>
-          <div className='text-lg font-medium'>Sign up</div>
-        </CardHeader>
-        <Divider />
-        <CardBody>
-          <div className='flex flex-col gap-3'>
-            <Input type='text' label='Name' size='sm' />
-            <Input type='email' label='Email' size='sm' />
-            <Input type='password' label='Password' size='sm' />
-          </div>
-        </CardBody>
-        <CardFooter>
-          <Button className='w-full bg-yellowaccent'>Sign Up</Button>
-        </CardFooter>
-      </Card>
+      <div className='text-[30px] font-main'>Text Preview</div>
+      <div className='text-[30px] font-menu-english'>Text Preview</div>
+      <div className='text-[30px] font-menu-japanese'>Text Preview</div>
+      <div className='text-[30px] font-ranking'>Text Preview</div>
+      <div className='text-[30px] font-sub'>Text Preview</div>
+      <div className='text-[30px] font-title'>Text Preview</div>
     </>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,6 +37,14 @@ module.exports = {
           DEFAULT: 'rgba(236, 184, 29, 1)', // Theme Color/Yellow
         },
       },
+      fontFamily: {
+        main: ['DotGothic16'],
+        'menu-english': ['Road Rage'],
+        'menu-japanese': ['Cuprum'],
+        ranking: ['Frijole'],
+        sub: ['Inter'],
+        title: ['Nosifer'],
+      },
     },
   },
 };


### PR DESCRIPTION
以下のissueに関するプルリクエストです。
#8 

1. フォントのインストール
2. tailwind.configとindex.cssへのフォントの登録
3. モック要素の設置
を行いました

導入できたことを分かりやすくするために、views/pages/Root/index.tsxにモックの要素を追加してあるので、チェックをお願いします。

以下の写真は、今回の実装による変化です。
|             Before              |              After              |
| :-----------------------------: | :-----------------------------: |
| <img width="450" alt="" src="https://github.com/kurakke/nitkit-shot/assets/72437090/3fb25a22-da05-48f1-a989-c019771f6bf0"> | <img width="450" alt="" src="https://github.com/kurakke/nitkit-shot/assets/72437090/d5411716-c8f9-4997-967b-6de65b8b540f"> |




