### PR TITLE
カラーパレットの一部名称を再定義

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,12 +19,15 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        'accent-green': {
+          DEFAULT: 'rgba(165, 208, 64, 1)', // Theme Color/Light Green
+        },
+        'accent-yellow': {
+          DEFAULT: 'rgba(236, 184, 29, 1)', // Theme Color/Yellow
+        },
         base: {
           DEFAULT: 'rgba(30, 30, 30, 1)', // Theme Color/Dark
           secondary: 'rgba(30, 30, 30, 0.50)', // Theme Color/Dark 50%
-        },
-        greenaccent: {
-          DEFAULT: 'rgba(165, 208, 64, 1)', // Theme Color/Light Green
         },
         light: {
           DEFAULT: 'rgba(241, 241, 241, 1)', // Theme Color/Light
@@ -32,9 +35,6 @@ module.exports = {
         main: {
           DEFAULT: 'rgba(1, 74, 46, 1)', // Theme Color/Deep Green
           secondary: 'rgba(1, 74, 46, 0.85)', // Theme Color/Deep Green 85%
-        },
-        yellowaccent: {
-          DEFAULT: 'rgba(236, 184, 29, 1)', // Theme Color/Yellow
         },
       },
       fontFamily: {


### PR DESCRIPTION
以下のissueに関するプルリクエストです。
#16  

カラーパレットの一部名称をハイフンを用いて分かりやすように再定義しました。