### PR TITLE
見出しのテキストコンポーネントを実装

### DIFF
--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const TitleText = ({ title }: Props): JSX.Element => {
   return (
-    <h2 className='mx-auto w-fit px-[15px] font-title text-[36px] text-accent-green md:text-[50px]'>
+    <h2 className='mx-auto w-fit font-title text-[36px] text-accent-green md:text-[50px]'>
       {title}
     </h2>
   );

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const TitleText = ({ title }: Props): JSX.Element => {
   return (
-    <h2 className='mx-auto w-fit font-title text-[40px] text-accent-green md:text-[50px]'>
+    <h2 className='mx-auto w-fit font-title text-[36px] text-accent-green'>
       {title}
     </h2>
   );

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const TitleText = ({ title }: Props): JSX.Element => {
   return (
-    <h2 className='mx-auto w-fit font-title text-[36px] text-accent-green md:text-[50px]'>
+    <h2 className='mx-auto w-fit px-[15px] font-title text-[36px] text-accent-green md:text-[50px]'>
       {title}
     </h2>
   );

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -1,0 +1,3 @@
+export const TitleText = (): JSX.Element => {
+  return <div></div>;
+};

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -1,7 +1,13 @@
+import { TitleId } from '../../types/TitleId';
+
 interface Props {
-  title: string;
+  title: TitleId;
 }
 
 export const TitleText = ({ title }: Props): JSX.Element => {
-  return <h2 className='mx-auto w-fit font-title text-[40px] text-accent-green md:text-[50px]'>{title}</h2>;
+  return (
+    <h2 className='mx-auto w-fit font-title text-[40px] text-accent-green md:text-[50px]'>
+      {title}
+    </h2>
+  );
 };

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -1,3 +1,7 @@
-export const TitleText = (): JSX.Element => {
-  return <div></div>;
+interface Props {
+  title: string;
+}
+
+export const TitleText = ({ title }: Props): JSX.Element => {
+  return <h2 className='mx-auto w-fit font-title text-[40px] text-accent-green md:text-[50px]'>{title}</h2>;
 };

--- a/src/components/TitleText.tsx
+++ b/src/components/TitleText.tsx
@@ -6,7 +6,7 @@ interface Props {
 
 export const TitleText = ({ title }: Props): JSX.Element => {
   return (
-    <h2 className='mx-auto w-fit font-title text-[36px] text-accent-green'>
+    <h2 className='mx-auto w-fit font-title text-[36px] text-accent-green md:text-[50px]'>
       {title}
     </h2>
   );

--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -8,9 +8,9 @@ import { ScrollToTopButton } from './ScrollToTopButton';
 
 export const DefaultLayout: ({ children }: LayoutProps) => JSX.Element = ({ children }) => {
   return (
-    <div className='inline-block h-full w-full bg-base'>
+    <div className='w-min-max inline-block h-full w-full min-w-max bg-base'>
       <HeaderBar />
-      <main className='mt-[110px] h-full w-full'>
+      <main className='mt-[110px] h-full min-h-screen w-full'>
         {children}
         <ScrollToTopButton />
       </main>

--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -8,9 +8,9 @@ import { ScrollToTopButton } from './ScrollToTopButton';
 
 export const DefaultLayout: ({ children }: LayoutProps) => JSX.Element = ({ children }) => {
   return (
-    <div className='w-min-max inline-block h-full w-full min-w-max bg-base'>
+    <div className='inline-block h-full w-full min-w-max bg-base'>
       <HeaderBar />
-      <main className='mt-[110px] h-full min-h-screen w-full'>
+      <main className='mt-[110px] h-full min-h-screen w-full '>
         {children}
         <ScrollToTopButton />
       </main>

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 
 import { DefaultLayout } from '../../../components/layouts/DefaultLayout';
 
+import { TitleText } from '@/components/TitleText';
+
 const RootPage: NextPage = () => {
   return (
     <DefaultLayout>
+      <TitleText title='introduction' />
       <div className='text-light'>kurakke</div>
       <div className='text-light'>kurakke</div>
       <div className='text-light'>kurakke</div>

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -14,7 +14,7 @@ const RootPage: NextPage = () => {
       <HeaderBar />
       <main className='mt-[100px]'>
         <ScrollToTopButton />
-        <TitleText title='Introduction' />
+        <TitleText title='introduction' />
         <div>kurakke</div>
         <div>kurakke</div>
         <div>kurakke</div>

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -1,12 +1,10 @@
 import { NextPage } from 'next';
 import React from 'react';
 
+import { TitleText } from '../../../components/TitleText';
+import Footer from '../../../components/layouts/Footer';
 import { HeaderBar } from '../../../components/layouts/HeaderBar';
 import { ScrollToTopButton } from '../../../components/layouts/ScrollToTopButton';
-
-// eslint-disable-next-line import/no-unresolved
-import { TitleText } from '@/components/TitleText';
-import Footer from '@/components/layouts/Footer';
 
 const RootPage: NextPage = () => {
   return (

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -5,6 +5,7 @@ import { HeaderBar } from '../../../components/layouts/HeaderBar';
 import { ScrollToTopButton } from '../../../components/layouts/ScrollToTopButton';
 
 // eslint-disable-next-line import/no-unresolved
+import { TitleText } from '@/components/TitleText';
 import Footer from '@/components/layouts/Footer';
 
 const RootPage: NextPage = () => {
@@ -13,6 +14,7 @@ const RootPage: NextPage = () => {
       <HeaderBar />
       <main className='mt-[100px]'>
         <ScrollToTopButton />
+        <TitleText title='Introduction' />
         <div>kurakke</div>
         <div>kurakke</div>
         <div>kurakke</div>

--- a/src/views/pages/Root/index.tsx
+++ b/src/views/pages/Root/index.tsx
@@ -1,9 +1,8 @@
 import { NextPage } from 'next';
 import React from 'react';
 
+import { TitleText } from '../../../components/TitleText';
 import { DefaultLayout } from '../../../components/layouts/DefaultLayout';
-
-import { TitleText } from '@/components/TitleText';
 
 const RootPage: NextPage = () => {
   return (

--- a/types/TitleId.ts
+++ b/types/TitleId.ts
@@ -1,0 +1,11 @@
+export type TitleId =
+  | 'about'
+  | 'information'
+  | 'reservation'
+  | 'ranking'
+  | 'access'
+  | 'introduction'
+  | 'for player'
+  | 'movie'
+  | 'q&a'
+  | 'credit';


### PR DESCRIPTION
以下のissueに関するプルリクエストです。
#25 

1. 見出しのテキストコンポーネントを実装 
2. types/TitleIdの定義
を行いました。

以下の写真は、今回の実装による変化です。
|             Before              |              After              |
| :-----------------------------: | :-----------------------------: |
| <img width="450" alt="" src="https://github.com/kurakke/nitkit-shot/assets/72437090/56898809-45fb-40b9-9696-1b0891d6e90d"> | <img width="450" alt="" src="https://github.com/kurakke/nitkit-shot/assets/72437090/a046332c-5ea8-4675-97a3-d5a9aa5237c8"> |