### PR TITLE
types/Sentenceの要素の属性を修正

### DIFF
--- a/constants/gamingVisualDataMock.ts
+++ b/constants/gamingVisualDataMock.ts
@@ -4,28 +4,16 @@ import { GamingVisual } from '../types/GamingVisual';
 export const GAMING_VISUAL_MOCK: GamingVisual = {
   // eslint-disable-next-line sort/object-properties
   zombie: {
-    description: {
-      firstParagraph: {
-        id: 'firstParagraph',
-        lines: [
-          'ゾンビ（英語: zombie）は、何らかの力で死体のまま蘇った人間の総称である。 多くはホラーやファンタジー作品などに登場し、「腐った死体が歩き回る」という描写が多くなされる架空の存在である。',
-        ],
-      },
-    },
+    description:
+      'ゾンビ（英語: zombie）は、何らかの力で死体のまま蘇った人間の総称である。 多くはホラーやファンタジー作品などに登場し、「腐った死体が歩き回る」という描写が多くなされる架空の存在である。',
     id: 'zombie',
     source: 'zombie.mp4',
     title: 'ゾンビ',
     type: 'video',
   },
   gun: {
-    description: {
-      firstParagraph: {
-        id: 'firstParagraph',
-        lines: [
-          'もともと鳥猟や小型の動物の狩猟用だが、大きな弾丸や一発弾なども使用でき、大型獣の狩猟にも用いられるようになった。 また、散弾銃を警備用として軍隊や警察で用いている国もある。',
-        ],
-      },
-    },
+    description:
+      'もともと鳥猟や小型の動物の狩猟用だが、大きな弾丸や一発弾なども使用でき、大型獣の狩猟にも用いられるようになった。 また、散弾銃を警備用として軍隊や警察で用いている国もある。',
     id: 'gun',
     source: logo,
     title: '散弾銃',

--- a/constants/guidelinesMock.ts
+++ b/constants/guidelinesMock.ts
@@ -4,40 +4,39 @@ export const GUIDELINES_MOCK: Sentence = {
   // eslint-disable-next-line sort/object-properties
   firstParagraph: {
     id: 'firstParagraph',
-    lines: ['銃をむやみに振り回さないで下さい。人やモノにぶつかる可能性がありとても危険です。'],
+    sentence: '銃をむやみに振り回さないで下さい。人やモノにぶつかる可能性がありとても危険です。',
   },
   secondParagraph: {
     id: 'secondParagraph',
-    lines: [
+    sentence:
       '銃を落とさないで下さい。中には精密機器が入っており一度の落下で破損するおそれがあります。',
-    ],
   },
   thirdParagraph: {
     id: 'thirdParagraph',
-    lines: ['銃を強く握りすぎないで下さい。破損するおそれがあります。'],
+    sentence: '銃を強く握りすぎないで下さい。破損するおそれがあります。',
   },
   fourthParagraph: {
     id: 'fourthParagraph',
-    lines: ['銃で殴らないで下さい。危ないです。'],
+    sentence: '銃で殴らないで下さい。危ないです。',
   },
   fifthParagraph: {
     id: 'fifthParagraph',
-    lines: ['銃を大切に扱って下さい。壊れると作成者が暴れます。'],
+    sentence: '銃を大切に扱って下さい。壊れると作成者が暴れます。',
   },
   sixthParagraph: {
     id: 'sixthParagraph',
-    lines: ['順番を守って下さい。揉めます。'],
+    sentence: '順番を守って下さい。揉めます。',
   },
   seventhParagraph: {
     id: 'seventhParagraph',
-    lines: ['予約をした人が優先です。当然です。'],
+    sentence: '予約をした人が優先です。当然です。',
   },
   eighthParagraph: {
     id: 'eighthParagraph',
-    lines: ['ルールを守って楽しく遊びましょう。'],
+    sentence: 'ルールを守って楽しく遊びましょう。',
   },
   ninthParagraph: {
     id: 'ninthParagraph',
-    lines: ['呼び出しても来られない場合は予約を繰り越す場合があります。ご了承下さい。'],
+    sentence: '呼び出しても来られない場合は予約を繰り越す場合があります。ご了承下さい。',
   },
 };

--- a/constants/storySentenceMock.ts
+++ b/constants/storySentenceMock.ts
@@ -4,52 +4,35 @@ export const STORY_SENTENCE_MOCK: Sentence = {
   // eslint-disable-next-line sort/object-properties
   firstParagraph: {
     id: 'firstParagraph',
-    lines: [
-      '何の変哲も無いある日の授業のこと。',
-      '「主人公を誰かに決める」はいつものように',
-      '居眠りをしてしまう。',
-    ],
+    sentence:
+      '何の変哲も無いある日の授業のこと。\n「主人公を誰かに決める」はいつものように居眠りをしてしまう。',
   },
   fourthParagraph: {
     id: 'fourthParagraph',
-    lines: [
-      '体を揺さぶられ目を覚ますと、',
-      'そこには銃を持った北園先生の姿と',
-      '倒れているゾンビの姿が…!!',
-    ],
+    sentence:
+      '体を揺さぶられ目を覚ますと、\nそこには銃を持った北園先生の姿と\n倒れているゾンビの姿が…!!',
   },
   secondParagraph: {
     id: 'secondParagraph',
-    lines: ['訳の分からない状況に呆然としていると、', '先生が状況を説明してくれた。'],
+    sentence: '訳の分からない状況に呆然としていると、\n先生が状況を説明してくれた。',
   },
   thirdParagraph: {
     id: 'thirdParagraph',
-    lines: ['ー'],
+    sentence: 'ー',
   },
   fifthParagraph: {
     id: 'fifthParagraph',
-    lines: [
-      'どうやら彼らはもともと高専生で、',
-      '単位を落として留年した者の怨念によって',
-      '進級した高専生や先生も襲い、',
-      '感染によりゾンビになってしまったようだ。',
-    ],
+    sentence:
+      'どうやら彼らはもともと高専生で、\n単位を落として留年した者の怨念によって\n進級した高専生や先生も襲い、\n感染によりゾンビになってしまったようだ。',
   },
   sixthParagraph: {
     id: 'sixthParagraph',
-    lines: [
-      'しかし、ゾンビになった彼らも',
-      '高専の魔法(こうせんマジック)のこもった銃で',
-      '撃つことで救済出来るとのこと。',
-    ],
+    sentence:
+      'しかし、ゾンビになった彼らも\n高専の魔法(こうせんマジック)のこもった銃で\n撃つことで救済出来るとのこと。',
   },
   seventhParagraph: {
     id: 'seventhParagraph',
-    lines: [
-      '半ば信じがたい状況だが、',
-      '先生から銃を受け取った「主人公を誰かに決め',
-      'る」は',
-      'ゾンビ達の救済に向かうのであった…',
-    ],
+    sentence:
+      '半ば信じがたい状況だが、\n先生から銃を受け取った「主人公を誰かに決める」は\nゾンビ達の救済に向かうのであった…',
   },
 };

--- a/src/components/general/GamingVisualContents.tsx
+++ b/src/components/general/GamingVisualContents.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 
 import { GamingVisualProps } from '../../../types/GamingVisual';
 
-import SentenceGenerator from './SentenceGenerator';
-
 const GamingVisualContents: (Props: Omit<GamingVisualProps, 'id'>) => JSX.Element = ({
   description,
   source,
@@ -20,9 +18,7 @@ const GamingVisualContents: (Props: Omit<GamingVisualProps, 'id'>) => JSX.Elemen
       )}
       {type === 'video' && <video src={source} controls className='h-[180px] w-full' />}
       <div className='text-[20px] font-bold text-accent-green'>{title}</div>
-      <div className='mr-auto'>
-        <SentenceGenerator sentence={description} textSize='text-[16px]' point={false} />
-      </div>
+      <p className='font-main text-light text-[16px]'>{description}</p>
     </div>
   );
 };

--- a/src/components/general/SentenceGenerator.tsx
+++ b/src/components/general/SentenceGenerator.tsx
@@ -32,10 +32,8 @@ const SentenceGenerator: ({ gap, leading, point, sentence, textSize }: Props) =>
       )}
     >
       {Object.values(sentence).map((paragraphs) => (
-        <li key={paragraphs.id}>
-          {Object.values(paragraphs.lines).map((texts) => (
-            <p key={texts}>{texts}</p>
-          ))}
+        <li key={paragraphs.id} className='whitespace-pre'>
+          {paragraphs.sentence}
         </li>
       ))}
     </ul>

--- a/src/components/topPage/About/index.tsx
+++ b/src/components/topPage/About/index.tsx
@@ -9,30 +9,30 @@ import { TitleText } from '../../general/TitleText';
 const INTRODUCTION_SENTENCE: Sentence = {
   firstParagraph: {
     id: 'firstParagraph',
-    lines: ['ある日突然北九州高専に', '現れたゾンビたち！！！！！！！！'],
+    sentence: 'ある日突然北九州高専に\n現れたゾンビたち！！！！！！！！',
   },
   secondParagraph: {
     id: 'secondParagraph',
-    lines: ['その正体は高専生と先生であった!?'],
+    sentence: 'その正体は高専生と先生であった!?',
   },
   thirdParagraph: {
     id: 'thirdParagraph',
-    lines: ['ゾンビを元の姿に戻すため4号館の奥へと歩み', '進めていくのだが……'],
+    sentence: 'ゾンビを元の姿に戻すため4号館の奥へと歩み\n進めていくのだが……',
   },
   fourthParagraph: {
     id: 'fourthParagraph',
-    lines: ['4I完全自作の', 'ハチャメチャゾンビシューティング！！！！'],
+    sentence: '4I完全自作の\nハチャメチャゾンビシューティング！！！！',
   },
 };
 
 const PS_SENTENCE: Sentence = {
-  firstSetence: {
+  firstParagraph: {
     id: 'firstParagraph',
-    lines: ['P.S.'],
+    sentence: 'P.S.',
   },
   secondParagraph: {
     id: 'secondParagraph',
-    lines: ['QRコードを読み取ってからプレイすると', 'いいことがあるかも…?'],
+    sentence: 'QRコードを読み取ってからプレイすると\nいいことがあるかも…?',
   },
 };
 

--- a/types/GamingVisual.ts
+++ b/types/GamingVisual.ts
@@ -1,11 +1,9 @@
-import { Sentence } from './Sentence';
-
 export interface GamingVisualProps {
   type: 'video' | 'picture';
   id: string;
   source: string;
   title: string;
-  description: Sentence;
+  description: string;
 }
 
 export type GamingVisual = Record<string, GamingVisualProps>;

--- a/types/Sentence.ts
+++ b/types/Sentence.ts
@@ -1,6 +1,6 @@
 interface SentenceProps {
   id: string;
-  lines: string[];
+  sentence: string;
 }
 
 export type Sentence = Record<string, SentenceProps>;

--- a/types/Sentence.ts
+++ b/types/Sentence.ts
@@ -1,6 +1,6 @@
-interface SentenceProps {
+type SentenceProps = {
   id: string;
   sentence: string;
-}
+};
 
 export type Sentence = Record<string, SentenceProps>;


### PR DESCRIPTION
以下のissueに関するPRです。
#81 

文章データの改行が`\n`で行えるようなので、types/Sentenceのsentenceをstring属性に変更しました。
合わせて、

1. 属性変更をモックデータへ反映
2. SentenceGeneratorの構造修正
3. GamingVisualPropsの要素の見直しとGamingVisualContentsの構造修正

を行いました。