### PR TITLE
スクロールトップボタンの表示に必要なスクロール量を変更・機能修正

### DIFF
--- a/src/components/layouts/ScrollToTopButton.tsx
+++ b/src/components/layouts/ScrollToTopButton.tsx
@@ -7,7 +7,7 @@ import ArrowShape from '../general/ArrowShape';
 
 export const ScrollToTopButton = (): JSX.Element => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
-  const visibleHeight: number = 500;
+  const visibleHeight: number = 1;
 
   const toTopButoonStyle = (visible: string, inVisible: string): string => {
     return isVisible ? visible : inVisible;

--- a/src/components/layouts/ScrollToTopButton.tsx
+++ b/src/components/layouts/ScrollToTopButton.tsx
@@ -38,7 +38,7 @@ export const ScrollToTopButton = (): JSX.Element => {
       <Button
         onClick={scrollToTop}
         className={classNames(
-          'transition-[opacity, visibility] duraction-500 fixed bottom-[78px] right-[15px] flex h-[48px] w-[48px] min-w-0 items-center justify-center rounded-[6px] border border-accent-green bg-accent-yellow',
+          'transition-[opacity, visibility] duraction-500 fixed bottom-[78px] right-[15px] z-[30] flex h-[48px] w-[48px] min-w-0 items-center justify-center rounded-[6px] border border-accent-green bg-accent-yellow',
           `${toTopButoonStyle(
             'translate-x-0', //表示時のスタイル
             'translate-x-[63px]', //非表示時のスタイル
@@ -46,7 +46,7 @@ export const ScrollToTopButton = (): JSX.Element => {
         )}
         aria-label='Scroll to top'
       >
-        <div className='mt-[7.5px]'>
+        <div className='mt-[7.5px] scale-125'>
           <ArrowShape direction='top' />
         </div>
       </Button>


### PR DESCRIPTION
以下のissueのPRです。
#86 
試行錯誤した結果、スクロールした瞬間にボタンが表示される方が自然だと思ったので変更しました。
追加でArrowShapeの大きさ変更と見出しが前面に表示される問題を解決しました。