### PR TITLE
トップページのロード画面が全画面表示されない問題を解決

### DIFF
--- a/src/components/animation/ui/Loading/index.tsx
+++ b/src/components/animation/ui/Loading/index.tsx
@@ -11,7 +11,7 @@ const Loading = () => {
     <div
       ref={ref}
       className={classNames(
-        `fixed z-50 flex h-full w-screen items-center justify-center bg-main`,
+        `fixed z-50 flex h-full w-full items-center justify-center bg-main`,
         `transition-all delay-[1500ms] duration-300 ease-in-out ${
           isIntersected ? 'invisible opacity-0' : 'visible opacity-100'
         }`,


### PR DESCRIPTION
以下のissueのPRです。
#91 
全画面にするCSSを 'w-screen' から 'w-full' に変更しました。
開発ツールを使ってロード画面表示中に画面幅を変えても問題なく動作します。